### PR TITLE
build: Bump compileSdk to 31

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
According to https://github.com/flutter/flutter/issues/153281 this seems to be issues with AndroidX dependency being upgraded causing all dependencies using SDK 30 or lower to be failing build.